### PR TITLE
fix: Copy dependabot-auto-merge.yml

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,8 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      - name: Authenticate cli with a PAT
+        run: echo "${{ secrets.DEPENDABOT_TOKEN }}" | gh auth login --with-token
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This PR copies the dependabot-auto-merge.yml script from core-fly.

Related to:
- https://github.com/CheckerNetwork/spark-stats/issues/158
- https://github.com/CheckerNetwork/spark-api/issues/350
