### PR TITLE
fix: move macOS linker flags to a Rust src file

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -72,18 +72,6 @@ fn build_lassie() {
     assert!(status.success(), "`go build` failed");
 
     println!("cargo:rustc-link-search=native={out_dir}");
-
-    #[cfg(target_os = "macos")]
-    {
-        // See https://github.com/golang/go/issues/11258
-        println!("cargo:rustc-link-arg=-framework");
-        println!("cargo:rustc-link-arg=CoreFoundation");
-        println!("cargo:rustc-link-arg=-framework");
-        println!("cargo:rustc-link-arg=Security");
-        // See https://github.com/golang/go/issues/58159
-        // println!("cargo:rustc-link-lib=resolv");
-        // ^^ Replaced with `-tags netgo`
-    }
 }
 
 #[cfg(all(target_os = "windows", target_env = "msvc"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,12 @@ extern "C" {
     fn DropResult(value: *mut LassieResult);
 }
 
+// See https://github.com/golang/go/issues/11258
+#[cfg_attr(target_os = "macos", link(name = "Security", kind = "framework"))]
+#[cfg_attr(target_os = "macos", link(name = "CoreFoundation", kind = "framework"))]
+extern "C" {}
+
+
 #[repr(C)]
 #[derive(Debug)]
 struct InitDaemonResult {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,7 @@ mod test {
             Ok(_) => panic!("starting another instance should have failed"),
 
             Err(err) => assert_eq!(err, StartError::OnlyOneInstanceAllowed),
-        };
+        }
     }
 
     #[test]
@@ -349,7 +349,7 @@ mod test {
                 );
             }
             Err(err) => panic!("unexpected error while starting Lassie on port 1: {err}"),
-        };
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,9 @@ extern "C" {
 
 // See https://github.com/golang/go/issues/11258
 #[cfg_attr(target_os = "macos", link(name = "Security", kind = "framework"))]
+extern "C" {}
 #[cfg_attr(target_os = "macos", link(name = "CoreFoundation", kind = "framework"))]
 extern "C" {}
-
 
 #[repr(C)]
 #[derive(Debug)]


### PR DESCRIPTION
When the linker flags were defined in `build.rs`, projects consuming `lassie` had to configure that flags again.

This commit moves the definition of those flags to a Rust source file. That should apply the flags when building consumers of this package too.

References:
- https://github.com/CheckerNetwork/zinnia/pull/712
- https://github.com/kornelski/rust-security-framework/blob/main/security-framework-sys/src/lib.rs
