### PR TITLE
deps: upgrade `log` to v0.4.20

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,8 +12,7 @@ updates:
     reviewers:
       - "bajtos"
     ignore:
-      # Keep the `log` crate at version ^0.17.0 to stay compatible with
-      # Deno crates that are pinning `log` version exactly to `0.17.0`
+      # Keep the `log` crate version pinned to stay compatible with Deno crates
       - dependency-name: "log"
 
   - package-ecosystem: "gomod"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log = "0.4.17"
+log = "0.4.20"
 
 [dev-dependencies]
 anyhow = "1.0.97"


### PR DESCRIPTION
Match the version used by Deno v2.2.9.

https://github.com/denoland/deno/blob/25defa74d539d1d6fd27ddabd5260705677c43e8/Cargo.toml#L183
